### PR TITLE
Fixed the link to Opening Ceremonies

### DIFF
--- a/user-registration-app/src/app/views/schedule-view/schedule-view.component.html
+++ b/user-registration-app/src/app/views/schedule-view/schedule-view.component.html
@@ -25,8 +25,11 @@
             </div>
             <div class="row justify-content-center">
               <div class="col-6">
-                <button *ngIf="isLink(activity.location_name)" class="event-btn" (click)="openZoomLink(activity.location_name)">
+                <button *ngIf="isZoomLink(activity.location_name)" class="event-btn" (click)="openZoomLink(activity.location_name)">
                   Join Via Zoom
+                </button>
+                <button *ngIf="isLink(activity.location_name) && !isZoomLink(activity.location_name)" class="event-btn" (click)="openZoomLink(activity.location_name)">
+                  Join
                 </button>
               </div>
               <div class="col-6">

--- a/user-registration-app/src/app/views/schedule-view/schedule-view.component.ts
+++ b/user-registration-app/src/app/views/schedule-view/schedule-view.component.ts
@@ -127,4 +127,8 @@ export class ScheduleViewComponent implements OnInit {
 
     return url.protocol === "http:" || url.protocol === "https:";
   }
+
+  isZoomLink(linkString: string): boolean {
+    return linkString.includes("zoom") && this.isLink(linkString)
+  }
 }


### PR DESCRIPTION
The link to Opening Ceremonies was already showing up in the event schedule, but it was labeled "join via zoom". The schedule view now applies "join via zoom" only to zoom links, and "join" to all other types of links (e.g. youtube).