### PR TITLE
Jdurrell/fix-vercel-again

### DIFF
--- a/user-registration-app/angular.json
+++ b/user-registration-app/angular.json
@@ -73,7 +73,11 @@
               "node_modules/hammerjs/hammer.js",
               "node_modules/materialize-css/dist/js/materialize.js"
             ],
-            "styles": ["./node_modules/@angular/material/prebuilt-themes/indigo-pink.css", "src/styles.css", "node_modules/materialize-css/dist/css/materialize.css"],
+            "styles": [
+              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+              "src/styles.css",
+              "node_modules/materialize-css/dist/css/materialize.css"
+            ],
             "assets": ["src/assets", "src/favicon.ico"]
           }
         },

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -1,8 +1,6 @@
 import { writeFile } from 'fs';
 
 // Only overwrite environment.ts if nodejs environment variables have been provided (i.e. only if Vercel is building)
-console.log('HELLO IS THIS THING ON');
-
 if ('PRODUCTION' in process.env) {
   const colors = require('colors');
   require('dotenv').load();
@@ -28,7 +26,6 @@ if ('PRODUCTION' in process.env) {
     rsvpStartTime: new Date('${process.env.RSVP_START_TIME}'),
   };
   `;
-  console.log('YES IT IS\n');
   console.log(
     colors.magenta('The file `environment.ts` will be written with the following content: \n')
   );

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -27,7 +27,9 @@ if ('PRODUCTION' in process.env) {
   };
   `;
   console.log(
-    colors.magenta('The file `environment.ts` will be written with the following content: \n')
+    colors.magenta(
+      'The files `environment.ts` and `environment.prod.ts` will be written with the following content: \n'
+    )
   );
   console.log(colors.grey(envConfigFile));
   writeFile(targetPath, envConfigFile, function (err) {
@@ -44,7 +46,7 @@ if ('PRODUCTION' in process.env) {
       throw console.error(err);
     } else {
       console.log(
-        colors.magenta(`Angular environment.ts file generated correctly at ${targetPath} \n`)
+        colors.magenta(`Angular environment.ts file generated correctly at ${targetPath2} \n`)
       );
     }
   });

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -20,7 +20,7 @@ if ('PRODUCTION' in process.env) {
       projectId: '${process.env.PROJECT_ID}',
       storageBucket: '${process.env.STORAGE_BUCKET}',
       messagingSenderId: '${process.env.MESSAGING_SENDER_ID}',
-    }
+    },
     liveWebsiteGuardTime: new Date('${process.env.LIVE_WEBSITE_GUARD_TIME}'),
     hackathonStartTime: new Date('${process.env.HACKATHON_START_TIME}'),
     timerStartTime: new Date('${process.env.TIMER_START_TIME}'),

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -1,6 +1,8 @@
 import { writeFile } from 'fs';
 
 // Only overwrite environment.ts if nodejs environment variables have been provided
+console.log('HELLO IS THIS THING ON');
+
 if (!process.env.PRODUCTION === undefined) {
   const colors = require('colors');
   require('dotenv').load();
@@ -26,6 +28,7 @@ if (!process.env.PRODUCTION === undefined) {
     rsvpStartTime: new Date('${process.env.RSVP_START_TIME}'),
   };
   `;
+  console.log('YES IT IS\n');
   console.log(
     colors.magenta('The file `environment.ts` will be written with the following content: \n')
   );

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -1,9 +1,9 @@
 import { writeFile } from 'fs';
 
-// Only overwrite environment.ts if nodejs environment variables have been provided
+// Only overwrite environment.ts if nodejs environment variables have been provided (i.e. only if Vercel is building)
 console.log('HELLO IS THIS THING ON');
 
-if (!process.env.PRODUCTION === undefined) {
+if ('PRODUCTION' in process.env) {
   const colors = require('colors');
   require('dotenv').load();
   const targetPath = './src/environments/environment.ts';

--- a/user-registration-app/set-env.ts
+++ b/user-registration-app/set-env.ts
@@ -11,8 +11,8 @@ if ('PRODUCTION' in process.env) {
 
   const envConfigFile = `export const environment = {
     production: '${process.env.PRODUCTION}',
-    api_url: '${process.env.API_BASE_URL}',
-    api_v2_url: '${process.env.API_URL}',
+    api_url: '${process.env.API_URL}',
+    api_v2_url: '${process.env.API_V2_URL}',
     firebase: {
       apiKey: '${process.env.API_KEY}',
       authDomain: '${process.env.AUTH_DOMAIN}',

--- a/user-registration-app/src/app/app.module.ts
+++ b/user-registration-app/src/app/app.module.ts
@@ -35,8 +35,8 @@ import { AuthService, CustomErrorHandlerService, HttpService } from './services/
 import { AuthGuard, DateGuard, LiveWebsiteDateGuard } from './services/route-guards/guards';
 import { TruncatePipe } from './services/pipes/truncate.pipe';
 import { NewlivefaqComponent } from './views/newlivefaq/newlivefaq.component';
-import {MatExpansionModule} from '@angular/material/expansion';
-import {MatIconModule} from "@angular/material/icon";
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
 @NgModule({
   declarations: [
     AppComponent,
@@ -70,7 +70,7 @@ import {MatIconModule} from "@angular/material/icon";
     NgProgressHttpModule,
     NgProgressRouterModule,
     NgxPaginationModule,
-    ToastrModule.forRoot({maxOpened: 5}),
+    ToastrModule.forRoot({ maxOpened: 5 }),
     RouterModule,
     MatExpansionModule,
     MatIconModule,


### PR DESCRIPTION
This should fix things. The script that overwrites the environment files wasn't properly checking whether it was being given environment variables from Vercel and it was failing to overwrite. As a result, the frontend was just using what was in the environment.ts file (since I stopped angular from replacing environment.ts with environment.prod.ts automatically like it used to).

Unfortunately, we won't definitely know for sure whether this will fix the production deployment until we actually merge it into master, but I've verified the key change between this PR and the build logs from when I first deployed the Vercel solution, so this should fix things.